### PR TITLE
Add question number to question in dropdown and plot

### DIFF
--- a/data-raw/gppt.R
+++ b/data-raw/gppt.R
@@ -58,7 +58,7 @@ gppt <-
   ) |>
   dplyr::mutate(
     question = stringr::str_squish(question),
-    # question = glue::glue("{question_number} - {question}"),
+    question = glue::glue("{question_number} - {question}"),
     answer = stringr::str_squish(answer),
     # create standardised/consistent ordinal scale for responses
     response_scale =


### PR DESCRIPTION
I've concatenated the question number and question in the GPPT data wrangling process, which now means the question number pulls through to both the question dropdown in the main panel and the subtitle in the plot.